### PR TITLE
add issue templates for CNX regression tests and release review epics

### DIFF
--- a/.github/ISSUE_TEMPLATE/cnx-regression-tests.md
+++ b/.github/ISSUE_TEMPLATE/cnx-regression-tests.md
@@ -1,0 +1,13 @@
+---
+name: CNX Regression Tests
+about: Recurring issue for each CNX release to track status of regression test runs in Zenhub.
+
+---
+
+CNX regression test run milestone link: INSERT TESTRAIL LINK
+
+- [ ] Check Sourav's credentials (`souravwebexpertindia`) on staging 
+- [ ] Prepare and send out test runs
+- [ ] Monitor/follow up on offshore testers 
+- [ ] Non-offshore regression tests
+- [ ] Batch regression tests 

--- a/.github/ISSUE_TEMPLATE/cnx-regression-tests.md
+++ b/.github/ISSUE_TEMPLATE/cnx-regression-tests.md
@@ -6,7 +6,7 @@ about: Recurring issue for each CNX release to track status of regression test r
 
 CNX regression test run milestone link: INSERT TESTRAIL LINK
 
-- [ ] Check Sourav's credentials (`souravwebexpertindia`) on staging 
+- [ ] Make sure Sourav can publish on staging 
 - [ ] Prepare and send out test runs
 - [ ] Monitor/follow up on offshore testers 
 - [ ] Non-offshore regression tests

--- a/.github/ISSUE_TEMPLATE/cnx-review-epic.md
+++ b/.github/ISSUE_TEMPLATE/cnx-review-epic.md
@@ -1,5 +1,5 @@
 ---
-name: Release Review Epic
+name: CNX Release Review Epic
 about: Create an issue as an Epic in Zenhub in order to track all issues for a given CNX release.
 
 ---

--- a/.github/ISSUE_TEMPLATE/cnx-review-epic.md
+++ b/.github/ISSUE_TEMPLATE/cnx-review-epic.md
@@ -1,0 +1,35 @@
+---
+name: Release Review Epic
+about: Create an issue as an Epic in Zenhub in order to track all issues for a given CNX release.
+
+---
+
+## Milestone dates:
+- Code freeze (no new features):  **DATE**
+- Code deployed to staging server: DATE
+- Testing on staging server: DATE => DATE
+- RC Review meeting: DATE
+- Code Released to Production: **DATE**
+
+
+## Link to release report
+in Zenhub
+
+## Repos updated:
+- oer.exports
+- webview
+- cnx-recipes
+- Products.RhaptosPrint
+- etc.
+
+## Demo:
+- 1
+- 2
+
+## No Demo:
+- 1
+- 2
+
+## Links to DevOps cards:
+- staging
+- prod


### PR DESCRIPTION
Add 2 new templates for issues that need to be created with every CNX release:

1. Release review epic (can be made into an epic within Zenhub)
1. Regression test runs

These are designed to be used within our Zenhub workflow. 